### PR TITLE
simplify variableset and variablemap implementations to avoid worst-c…

### DIFF
--- a/DecisionDiagramTests/DiagramTests.cs
+++ b/DecisionDiagramTests/DiagramTests.cs
@@ -1720,6 +1720,42 @@ namespace DecisionDiagramTests
         }
 
         /// <summary>
+        /// Test that quantification works when adding new variables.
+        /// </summary>
+        [TestMethod]
+        public void TestExistsAlternatingVariables()
+        {
+            var manager = new DDManager<T>(this.Factory, 8, 8, true);
+            var a = manager.CreateBool();
+            var b = manager.CreateBool();
+            var c = manager.CreateBool();
+            var d = manager.CreateBool();
+            var f1 = manager.And(a.Id(), manager.And(b.Id(), manager.And(c.Id(), d.Id())));
+            var f2 = manager.And(a.Id(), c.Id());
+            var variableSet = manager.CreateVariableSet(new Variable<T>[] { b, d });
+            var f3 = manager.Exists(f1, variableSet);
+            Assert.AreEqual(f2, f3);
+        }
+
+        /// <summary>
+        /// Test that quantification works when adding new variables.
+        /// </summary>
+        [TestMethod]
+        public void TestExistsWithDontCareVariables()
+        {
+            var manager = new DDManager<T>(this.Factory, 8, 8, true);
+            var a = manager.CreateBool();
+            var b = manager.CreateBool();
+            var c = manager.CreateBool();
+            var d = manager.CreateBool();
+            var f1 = manager.And(a.Id(), manager.And(b.Id(), d.Id()));
+            var f2 = manager.And(a.Id(), d.Id());
+            var variableSet = manager.CreateVariableSet(new Variable<T>[] { b, c });
+            var f3 = manager.Exists(f1, variableSet);
+            Assert.AreEqual(f2, f3);
+        }
+
+        /// <summary>
         /// Test replace with random.
         /// </summary>
         [TestMethod]
@@ -1954,6 +1990,24 @@ namespace DecisionDiagramTests
             var variableMap = manager.CreateVariableMap(map);
             var f3 = manager.Replace(f1, variableMap);
             Assert.AreEqual(f2, f3);
+        }
+
+        /// <summary>
+        /// Test replacing a variable in the middle of a chain.
+        /// </summary>
+        [TestMethod]
+        public void TestReplaceSkippingLevel()
+        {
+            var manager = new DDManager<T>(this.Factory, 8, 8, true);
+            var a = manager.CreateBool();
+            var b = manager.CreateBool();
+            var c = manager.CreateBool();
+            var d = manager.CreateBool();
+            var e = manager.CreateBool();
+            var f = manager.And(a.Id(), manager.And(b.Id(), d.Id()));
+            var map = new Dictionary<Variable<T>, Variable<T>> { { c, e } };
+            var variableMap = manager.CreateVariableMap(map);
+            Assert.AreEqual(f, manager.Replace(f, variableMap));
         }
 
         /// <summary>

--- a/DecisionDiagrams/VariableSet.cs
+++ b/DecisionDiagrams/VariableSet.cs
@@ -5,7 +5,7 @@
 namespace DecisionDiagrams
 {
     using System;
-    using System.Collections;
+    using System.Collections.Generic;
 
     /// <summary>
     /// Represents a set of variables.
@@ -17,12 +17,7 @@ namespace DecisionDiagrams
         /// <summary>
         /// The set of variables.
         /// </summary>
-        private BitArray variables;
-
-        /// <summary>
-        /// Gets the smallest index in the set.
-        /// </summary>
-        internal int MinIndex { get; } = -1;
+        private HashSet<int> variables;
 
         /// <summary>
         /// Gets the largest index in the set.
@@ -55,6 +50,7 @@ namespace DecisionDiagrams
             this.ManagerId = manager.Uid;
             this.AsIndex = DDIndex.True;
             this.Variables = variables;
+            this.variables = new HashSet<int>();
 
             for (int i = 0; i < variables.Length; i++)
             {
@@ -62,21 +58,9 @@ namespace DecisionDiagrams
                 for (int j = v.Indices.Length - 1; j >= 0; j--)
                 {
                     var variableIndex = v.Indices[j];
-                    this.MinIndex = this.MinIndex < 0 ? variableIndex : Math.Min(this.MinIndex, variableIndex);
                     this.MaxIndex = Math.Max(this.MaxIndex, variableIndex);
                     this.AsIndex = manager.And(this.AsIndex, manager.IdIdx(variableIndex));
-                }
-            }
-
-            this.variables = new BitArray(this.MaxIndex - this.MinIndex + 1);
-
-            for (int i = 0; i < variables.Length; i++)
-            {
-                var v = variables[i];
-                for (int j = v.Indices.Length - 1; j >= 0; j--)
-                {
-                    var variableIndex = v.Indices[j];
-                    this.variables.Set(variableIndex - this.MinIndex, true);
+                    this.variables.Add(variableIndex);
                 }
             }
         }
@@ -88,13 +72,7 @@ namespace DecisionDiagrams
         /// <returns>Whether the set contains that variable.</returns>
         internal bool Contains(int variable)
         {
-            if (variable < this.MinIndex)
-            {
-                return false;
-            }
-
-            var index = variable - this.MinIndex;
-            return this.variables.Get(index);
+            return this.variables.Contains(variable);
         }
     }
 }


### PR DESCRIPTION
- VariableSet and VariableMap currently use efficient array and bitset implementations. However, they become problematic when the manager allocates many (thousands) of variables as each set/map must allocate a large array or bitset.
- This replaces these implementations with HashSet and Dictionary to avoid the worst case since the overhead appears to be quite small.